### PR TITLE
(WIP)SWRによるデータフェッチ。ページ毎に401リダイレクト処理を書かなくても良いように

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -25,6 +25,7 @@
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.14.1",
         "react-scripts": "5.0.1",
+        "swr": "^2.2.2",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
       }
@@ -6252,6 +6253,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
     "node_modules/cliui": {
       "version": "7.0.4",
@@ -16303,6 +16309,18 @@
       "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
       "dependencies": {
         "boolbase": "~1.0.0"
+      }
+    },
+    "node_modules/swr": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.2.2.tgz",
+      "integrity": "sha512-CbR41AoMD4TQBQw9ic3GTXspgfM9Y8Mdhb5Ob4uIKXhWqnRLItwA5fpGvB7SmSw3+zEjb0PdhiEumtUvYoQ+bQ==",
+      "dependencies": {
+        "client-only": "^0.0.1",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/symbol-tree": {

--- a/front/package.json
+++ b/front/package.json
@@ -20,6 +20,7 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.14.1",
     "react-scripts": "5.0.1",
+    "swr": "^2.2.2",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"
   },

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -5,8 +5,11 @@ import { SWRConfig } from "swr";
 import { axios } from "./axiosClient";
 import { useNavigate } from "react-router-dom";
 import { BrowserRouter as Router } from "react-router-dom";
+import { useState } from "react";
 
 const FetcherComponent = () => {
+  // 初回のフェッチをトラッキングするstate
+  const [initialFetch, setInitialFetch] = useState(true);
   const navigate = useNavigate();
 
   const swrConfigValue = {
@@ -15,13 +18,17 @@ const FetcherComponent = () => {
         const response = await axios.get(url, {
           baseURL: "http://localhost/api",
         });
+        if (initialFetch) setInitialFetch(false);
         return response.data;
       } catch (error: any) {
-        if (error.response.status === 401) {
+        // ページ初回読み込み＆401エラーの場合はログインページにリダイレクト
+        if (initialFetch && error.response.status === 401) {
           navigate("/login");
         }
       }
     },
+    errorRetryCount: 0,
+    shouldRetryOnError: false,
   };
 
   return (

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -1,13 +1,42 @@
-import React from "react";
-import { RouterProvider } from "react-router-dom";
-import { router } from "./routes";
+import RouterContent from "./routes";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { queryClient } from "./queryClient";
+import { SWRConfig } from "swr";
+import { axios } from "./axiosClient";
+import { useNavigate } from "react-router-dom";
+import { BrowserRouter as Router } from "react-router-dom";
+
+const FetcherComponent = () => {
+  const navigate = useNavigate();
+
+  const swrConfigValue = {
+    fetcher: async (url: string) => {
+      try {
+        const response = await axios.get(url, {
+          baseURL: "http://localhost/api",
+        });
+        return response.data;
+      } catch (error: any) {
+        if (error.response.status === 401) {
+          navigate("/login");
+        }
+      }
+    },
+  };
+
+  return (
+    <SWRConfig value={swrConfigValue}>
+      <RouterContent />
+    </SWRConfig>
+  );
+};
 
 const App = () => {
   return (
     <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
+      <Router>
+        <FetcherComponent />
+      </Router>
     </QueryClientProvider>
   );
 };

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -29,6 +29,7 @@ const FetcherComponent = () => {
     },
     errorRetryCount: 0,
     shouldRetryOnError: false,
+    revalidateOnFocus: false,
   };
 
   return (

--- a/front/src/Dashboard.tsx
+++ b/front/src/Dashboard.tsx
@@ -1,21 +1,18 @@
-import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { TransitionLoader } from "./TransitionLoader";
 import { axios } from "./axiosClient";
 import useSWR from "swr";
 
-// type User = {
-//   id: number;
-//   name: string;
-//   email: string;
-// }
+type User = {
+  id: number;
+  name: string;
+  email: string;
+}
 
 const DashboardPage = () => {
-  // const [user,setUser] = useState<User>();
-  // const [loading,setLoading] = useState(true);
   const navigate = useNavigate();
 
-  const {data:userData} = useSWR('/user')
+  const {data:userData,isLoading:userIsLoading} = useSWR<User>('/user')
 
   const logout = async() => {
     await axios.post("http://localhost/api/logout")
@@ -27,7 +24,7 @@ const DashboardPage = () => {
     })
   }
 
-  // リクエストヘッダーにトークンが付与されている？のでエラーにならない
+  // リクエストヘッダーにトークンが付与されているのでエラーにならない
   const getUser = async() => {
     await axios.get("http://localhost/api/user")
     .then((res) => {
@@ -40,7 +37,7 @@ const DashboardPage = () => {
 
   return (
     <div>
-      {/* {loading && <TransitionLoader />} */}
+      {userIsLoading && <TransitionLoader />}
       <h1>ダッシュボード</h1>
       <h2>ユーザー情報</h2>
       {userData && (

--- a/front/src/Dashboard.tsx
+++ b/front/src/Dashboard.tsx
@@ -1,38 +1,24 @@
-import axios from "axios";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { TransitionLoader } from "./TransitionLoader";
+import { axios } from "./axiosClient";
+import useSWR from "swr";
 
-const Axios = axios.create({
-  withCredentials: true,
-});
-
-type User = {
-  id: number;
-  name: string;
-  email: string;
-}
+// type User = {
+//   id: number;
+//   name: string;
+//   email: string;
+// }
 
 const DashboardPage = () => {
-  const [user,setUser] = useState<User>();
-  const [loading,setLoading] = useState(true);
+  // const [user,setUser] = useState<User>();
+  // const [loading,setLoading] = useState(true);
   const navigate = useNavigate();
-  useEffect(()=>{
-    const fetchDate = async() => await Axios.get("http://localhost/api/user")
-    .then((res) => {
-      console.log(res);
-      setUser(res.data)
-      setLoading(false);
-    })
-    .catch((err) => {
-      navigate("/login");
-    })
 
-    fetchDate();
-  },[navigate])
+  const {data:userData} = useSWR('/user')
 
   const logout = async() => {
-    await Axios.post("http://localhost/api/logout")
+    await axios.post("http://localhost/api/logout")
     .then(() => {
       navigate("/login");
     })
@@ -43,7 +29,7 @@ const DashboardPage = () => {
 
   // リクエストヘッダーにトークンが付与されている？のでエラーにならない
   const getUser = async() => {
-    await Axios.get("http://localhost/api/user")
+    await axios.get("http://localhost/api/user")
     .then((res) => {
       console.log(res);
     })
@@ -54,13 +40,13 @@ const DashboardPage = () => {
 
   return (
     <div>
-      {loading && <TransitionLoader />}
+      {/* {loading && <TransitionLoader />} */}
       <h1>ダッシュボード</h1>
       <h2>ユーザー情報</h2>
-      {user && (
+      {userData && (
         <div>
-          <h1>{user.name}</h1>
-          <h1>{user.email}</h1>
+        <h1>{userData.name}</h1>
+        <h1>{userData.email}</h1>
         </div>
       )}
       <button onClick={logout}>ログアウト</button>

--- a/front/src/Login.tsx
+++ b/front/src/Login.tsx
@@ -1,10 +1,6 @@
-import axios from "axios";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-
-const Axios = axios.create({
-  withCredentials: true,
-});
+import { axios } from "./axiosClient";
 
 const LoginPage = () => {
   const navigate = useNavigate();
@@ -13,8 +9,8 @@ const LoginPage = () => {
   const [password, setPassword] = useState('');
 
   const handleClick = async () => {
-    await Axios.get("http://localhost/sanctum/csrf-cookie").then((res) => {
-      Axios.post("http://localhost/api/login", {
+    await axios.get("http://localhost/sanctum/csrf-cookie").then((res) => {
+      axios.post("http://localhost/api/login", {
         email: email,
         password: password,
       }).then((res) => {
@@ -26,7 +22,7 @@ const LoginPage = () => {
 
   // ダッシュボードとの比較。こちらはリクエストヘッダーにトークンが付与されていないのでエラーになる。
   const getUser = async() => {
-    await Axios.get("http://localhost/api/user")
+    await axios.get("http://localhost/api/user")
     .then((res) => {
       console.log(res);
     })

--- a/front/src/axiosClient.tsx
+++ b/front/src/axiosClient.tsx
@@ -1,0 +1,19 @@
+import Axios, { AxiosError } from "axios";
+
+export const axios = Axios.create({
+  baseURL: "http://localhost:3000",
+  headers: {
+    "Content-Type": "application/json",
+  },
+  withCredentials: true,
+});
+
+// レスポンスインターセプターを追加
+axios.interceptors.response.use(
+  (response) => {
+    return response;
+  },
+  (error: AxiosError) => {
+    return Promise.reject(error);
+  }
+);

--- a/front/src/routes.tsx
+++ b/front/src/routes.tsx
@@ -1,14 +1,14 @@
-import { createBrowserRouter } from "react-router-dom";
+import { Route, Routes } from "react-router-dom";
 import DashboardPage from "./Dashboard";
 import LoginPage from "./Login";
 
-export const router = createBrowserRouter([
-  {
-    path: "login",
-    element: <LoginPage />,
-  },
-  {
-    path: "/",
-    element: <DashboardPage />,
-  },
-]);
+const RouterContent = () => {
+  return (
+    <Routes>
+      <Route path="login" element={<LoginPage />} />
+      <Route path="/" element={<DashboardPage />} />
+    </Routes>
+  );
+}
+
+export default RouterContent;


### PR DESCRIPTION
- swrインストール `npm install swr`
- 認証後にトークン情報を付与したaxiosラッパー追加
- APIデータ初期フェッチ時に認証エラーが出ていた際にはログインページにリダイレクトされるようにSWR設定。
- リフェッチ時の不具合を解消（不具合というより、システム開発でのスタンダードな仕様に対応できるようにSWRの設定を変更）